### PR TITLE
Fix error handler type in KafkaDemo3

### DIFF
--- a/KafkaDemo3/src/main/java/com/example/kafkademo3/KafkaErrorHandler.java
+++ b/KafkaDemo3/src/main/java/com/example/kafkademo3/KafkaErrorHandler.java
@@ -1,29 +1,26 @@
 package com.example.kafkademo3;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.kafka.listener.ListenerExecutionFailedException;
-import org.springframework.messaging.Message;
+import org.springframework.kafka.listener.ConsumerAwareErrorHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * Kafka错误处理器
  */
 @Component
-class KafkaErrorHandler implements org.springframework.kafka.listener.ConsumerAwareListenerErrorHandler {
+public class KafkaErrorHandler implements ConsumerAwareErrorHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(KafkaErrorHandler.class);
 
     @Override
-    public Object handleError(Message<?> message, ListenerExecutionFailedException exception,
-                              Consumer<?, ?> consumer) {
-        logger.error("Kafka listener error - Message: {}, Exception: {}",
-                message.getPayload(), exception.getMessage(), exception);
+    public void handle(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer) {
+        logger.error("Kafka listener error - Record: {}, Exception: {}",
+                record, thrownException.getMessage(), thrownException);
 
         // 实现错误处理逻辑
         // 例如：发送到死信队列、记录错误日志、发送告警等
-
-        return null;
     }
 }


### PR DESCRIPTION
## Summary
- implement `ConsumerAwareErrorHandler` in `KafkaErrorHandler`
- adjust method signature to match `ConsumerAwareErrorHandler`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684917e1c1b88327a3cb7431e9ad8fe4